### PR TITLE
Tanay unit-tests and refactoring for NCF recommender 

### DIFF
--- a/ncf_inference/NCF.py
+++ b/ncf_inference/NCF.py
@@ -28,7 +28,7 @@ import TrainDataset as td
 
 class NCF(pl.LightningModule):
 
-    def __init__(self, num_users, num_items, ratings, all_item_ids):
+    def __init__(self, num_users, num_items, ratings, all_item_ids, num_workers):
         super().__init__()
         self.user_embedding = nn.Embedding(num_embeddings=num_users, embedding_dim=8)
         self.item_embedding = nn.Embedding(num_embeddings=num_items, embedding_dim=8)
@@ -37,6 +37,7 @@ class NCF(pl.LightningModule):
         self.output = nn.Linear(in_features=32, out_features=1)
         self.ratings = ratings
         self.all_item_ids = all_item_ids
+        self.num_workers = num_workers
 
     def forward(self, user_input, item_input):
         # Pass through embedding layers
@@ -66,4 +67,4 @@ class NCF(pl.LightningModule):
 
     def train_dataloader(self):
         return DataLoader(td.TrainDataset(self.ratings, self.all_item_ids),
-                          batch_size=512, num_workers=4)
+                          batch_size=512, num_workers=self.num_workers)

--- a/ncf_inference/NCF.py
+++ b/ncf_inference/NCF.py
@@ -28,7 +28,7 @@ import TrainDataset as td
 
 class NCF(pl.LightningModule):
 
-    def __init__(self, num_users, num_items, ratings, all_item_ids, num_workers):
+    def __init__(self, num_users, num_items, ratings, all_item_ids, batch_size, num_workers):
         super().__init__()
         self.user_embedding = nn.Embedding(num_embeddings=num_users, embedding_dim=8)
         self.item_embedding = nn.Embedding(num_embeddings=num_items, embedding_dim=8)
@@ -37,6 +37,7 @@ class NCF(pl.LightningModule):
         self.output = nn.Linear(in_features=32, out_features=1)
         self.ratings = ratings
         self.all_item_ids = all_item_ids
+        self.batch_size = batch_size
         self.num_workers = num_workers
 
     def forward(self, user_input, item_input):
@@ -67,4 +68,4 @@ class NCF(pl.LightningModule):
 
     def train_dataloader(self):
         return DataLoader(td.TrainDataset(self.ratings, self.all_item_ids),
-                          batch_size=512, num_workers=self.num_workers)
+                          batch_size=self.batch_size, num_workers=self.num_workers)

--- a/ncf_inference/requirements.txt
+++ b/ncf_inference/requirements.txt
@@ -47,7 +47,6 @@ six==1.16.0
 tensorboard==2.9.0
 tensorboard-data-server==0.6.1
 tensorboard-plugin-wit==1.8.1
-tokenizers==0.12.1
 torch==1.10.2
 torchmetrics==0.8.2
 tqdm==4.64.0
@@ -58,3 +57,4 @@ Werkzeug==2.0.3
 yarl==1.7.2
 zipp==3.6.0
 msrest==0.6.21
+coverage

--- a/ncf_inference/requirements.txt
+++ b/ncf_inference/requirements.txt
@@ -23,10 +23,10 @@ importlib-resources==5.4.0
 joblib==1.1.0
 Markdown==3.3.7
 multidict==5.2.0
-numpy==1.19.5
+numpy
 oauthlib==3.2.0
 packaging==21.3
-pandas==1.1.5
+pandas
 protobuf==3.19.4
 pyasn1==0.4.8
 pyasn1-modules==0.2.8

--- a/ncf_inference/unittest_train_dataset.py
+++ b/ncf_inference/unittest_train_dataset.py
@@ -8,19 +8,23 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 class test_train(unittest.TestCase):
     @classmethod
     def setUpClass(self):
+        ''' Function used to set up test dataframe and unittesting parameters '''
+        # Create a dataframe for testing
         self.ratings = pandas.DataFrame({ 
             'user_id': [0,0,0,1,1,1,2,2,2,3,3,3,4,4,4],
             'item_id': [0,0,0,1,1,1,2,2,2,3,3,3,4,4,4],
         })
+        # Retrieve all unique items in a list
         self.all_item_ids = list(set(self.ratings['item_id']))
 
-        # Call the get_dataset function on the above data
+        # Call the get_dataset function on the above defined data
         self.td = TrainDataset(self.ratings, self.all_item_ids)
         self.data_item_label_tuple = set()
         for user, item, label in zip(list(self.td.users), list(self.td.items), list(self.td.labels)):
             self.data_item_label_tuple.add((user, item, label))
 
     def data_labels_helper(self):
+        ''' Checks if get_dataset function assigns correct labels to each user, item pair - based on the data defined in setUpClass above '''
         for user, item, label in self.data_item_label_tuple:
             if (user == item):
                 if label == 0:
@@ -31,7 +35,7 @@ class test_train(unittest.TestCase):
         return True
 
     def test_data_labels(self):
-        ''' Checks if the get_data function produces the correct labels '''
+        ''' Checks if the get_dataset function produces the correct labels '''
         self.assertTrue(
             self.data_labels_helper()
         )

--- a/ncf_inference/unittest_train_dataset.py
+++ b/ncf_inference/unittest_train_dataset.py
@@ -31,6 +31,7 @@ class test_train(unittest.TestCase):
         return True
 
     def test_data_labels(self):
+        ''' Checks if the get_data function produces the correct labels '''
         self.assertTrue(
             self.data_labels_helper()
         )

--- a/ncf_inference/unittest_train_dataset.py
+++ b/ncf_inference/unittest_train_dataset.py
@@ -1,0 +1,36 @@
+import pandas
+import unittest
+import os
+import sys
+from TrainDataset import TrainDataset
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+class test_train(unittest.TestCase):
+    @classmethod
+    def setUpClass(self):
+        self.ratings = pandas.DataFrame({ 
+            'user_id': [0,0,0,1,1,1,2,2,2,3,3,3,4,4,4],
+            'item_id': [0,0,0,1,1,1,2,2,2,3,3,3,4,4,4],
+        })
+        self.all_item_ids = list(set(self.ratings['item_id']))
+
+        # Call the get_dataset function on the above data
+        self.td = TrainDataset(self.ratings, self.all_item_ids)
+        self.data_item_label_tuple = set()
+        for user, item, label in zip(list(self.td.users), list(self.td.items), list(self.td.labels)):
+            self.data_item_label_tuple.add((user, item, label))
+
+    def data_labels_helper(self):
+        for user, item, label in self.data_item_label_tuple:
+            if (user == item):
+                if label == 0:
+                    return False
+            else:
+                if label == 1:
+                    return False
+        return True
+
+    def test_data_labels(self):
+        self.assertTrue(
+            self.data_labels_helper()
+        )

--- a/ncf_train/NCF.py
+++ b/ncf_train/NCF.py
@@ -46,4 +46,5 @@ class NCF(pl.LightningModule):
 
     def train_dataloader(self):
         return DataLoader(td.TrainDataset(self.ratings, self.all_item_ids),
-                          batch_size=self.batch_size, num_workers=4)
+                          batch_size=self.batch_size, num_workers=0)
+                          

--- a/ncf_train/NCF.py
+++ b/ncf_train/NCF.py
@@ -7,7 +7,7 @@ import TrainDataset as td
 
 class NCF(pl.LightningModule):
 
-    def __init__(self, num_users, num_items, ratings, all_item_ids, batch_size):
+    def __init__(self, num_users, num_items, ratings, all_item_ids, batch_size, num_workers):
         super().__init__()
         self.user_embedding = nn.Embedding(num_embeddings=num_users, embedding_dim=8)
         self.item_embedding = nn.Embedding(num_embeddings=num_items, embedding_dim=8)
@@ -17,6 +17,7 @@ class NCF(pl.LightningModule):
         self.ratings = ratings
         self.all_item_ids = all_item_ids
         self.batch_size = batch_size
+        self.num_workers = num_workers
 
     def forward(self, user_input, item_input):
         # Pass through embedding layers
@@ -46,5 +47,4 @@ class NCF(pl.LightningModule):
 
     def train_dataloader(self):
         return DataLoader(td.TrainDataset(self.ratings, self.all_item_ids),
-                          batch_size=self.batch_size, num_workers=0)
-                          
+                          batch_size=self.batch_size, num_workers=self.num_workers)

--- a/ncf_train/requirements.txt
+++ b/ncf_train/requirements.txt
@@ -47,7 +47,6 @@ six==1.16.0
 tensorboard==2.9.0
 tensorboard-data-server==0.6.1
 tensorboard-plugin-wit==1.8.1
-tokenizers==0.12.1
 torch==1.10.2
 torchmetrics==0.8.2
 tqdm==4.64.0

--- a/ncf_train/requirements.txt
+++ b/ncf_train/requirements.txt
@@ -23,10 +23,10 @@ importlib-resources==5.4.0
 joblib==1.1.0
 Markdown==3.3.7
 multidict==5.2.0
-numpy==1.19.5
+numpy
 oauthlib==3.2.0
 packaging==21.3
-pandas==1.1.5
+pandas
 protobuf==3.19.4
 pyasn1==0.4.8
 pyasn1-modules==0.2.8

--- a/ncf_train/requirements.txt
+++ b/ncf_train/requirements.txt
@@ -57,3 +57,4 @@ Werkzeug==2.0.3
 yarl==1.7.2
 zipp==3.6.0
 msrest==0.6.21
+coverage

--- a/ncf_train/train.py
+++ b/ncf_train/train.py
@@ -63,7 +63,7 @@ def get_data_attributes(ratings, train_ratings):
     all_item_ids = ratings['item_id'].unique()
     return train_ratings, num_users, num_items, all_item_ids
 
-def fit_model():
+def fit_model(num_users, num_items, train_ratings, all_item_ids, batch_size, epochs):
     ''' Calls the training function  '''
     model = ncf.NCF(num_users, num_items, train_ratings, all_item_ids, batch_size)
     trainer = pl.Trainer(max_epochs=int(epochs), reload_dataloaders_every_n_epochs=True, enable_checkpointing=False, log_every_n_steps=1)
@@ -82,7 +82,7 @@ def get_test_attributes(test_ratings, ratings):
     user_interacted_items = ratings.groupby('user_id')['item_id'].apply(list).to_dict()
     return test_user_item_set, user_interacted_items
 
-def get_recall(test_user_item_set, user_interacted_items):
+def get_recall(test_user_item_set, user_interacted_items, model):
     ''' Calculates average recall '''
     recall = []
     for (u, i) in test_user_item_set:
@@ -142,9 +142,9 @@ if __name__ == "__main__":
     # eval_metrics_whole = pd.DataFrame(columns=['user_id', 'rmse', 'precision', 'recall']) - is this used ?
  
     train_ratings, num_users, num_items, all_item_ids = get_data_attributes(ratings, train_ratings)
-    model, trainer = fit_model()
+    model, trainer = fit_model(num_users, num_items, train_ratings, all_item_ids, batch_size, epochs)
     test_user_item_set, user_interacted_items = get_test_attributes(test_ratings, ratings)
 
-    average_recall = get_recall(test_user_item_set, user_interacted_items)
+    average_recall = get_recall(test_user_item_set, user_interacted_items, model)
     print("The hit ratio @ 10 is {:.2f}".format(average_recall))
     save_pt_model(file_dir, output_model_file)

--- a/ncf_train/train.py
+++ b/ncf_train/train.py
@@ -82,7 +82,7 @@ def get_test_attributes(test_ratings, ratings):
     user_interacted_items = ratings.groupby('user_id')['item_id'].apply(list).to_dict()
     return test_user_item_set, user_interacted_items
 
-def get_recall(test_user_item_set, user_interacted_items, model):
+def get_recall(test_user_item_set, user_interacted_items, all_item_ids, model):
     ''' Calculates average recall '''
     recall = []
     for (u, i) in test_user_item_set:
@@ -93,7 +93,6 @@ def get_recall(test_user_item_set, user_interacted_items, model):
 
         predicted_labels = np.squeeze(model(torch.tensor([u] * 100),
                                             torch.tensor(test_items)).detach().numpy())
-
         top10_items = [test_items[i] for i in np.argsort(predicted_labels)[::-1][0:10].tolist()]
 
         if i in top10_items:
@@ -102,7 +101,7 @@ def get_recall(test_user_item_set, user_interacted_items, model):
             recall.append(0)
     return np.average(recall)
 
-def save_pt_model(file_dir, output_model_file):
+def save_pt_model(model, file_dir, output_model_file):
     torch.save(model, file_dir + "/" + output_model_file)
 
 if __name__ == "__main__":
@@ -145,6 +144,6 @@ if __name__ == "__main__":
     model, trainer = fit_model(num_users, num_items, train_ratings, all_item_ids, batch_size, epochs)
     test_user_item_set, user_interacted_items = get_test_attributes(test_ratings, ratings)
 
-    average_recall = get_recall(test_user_item_set, user_interacted_items, model)
+    average_recall = get_recall(test_user_item_set, user_interacted_items, all_item_ids, model)
     print("The hit ratio @ 10 is {:.2f}".format(average_recall))
-    save_pt_model(file_dir, output_model_file)
+    save_pt_model(model, file_dir, output_model_file)

--- a/ncf_train/train.py
+++ b/ncf_train/train.py
@@ -1,7 +1,5 @@
 import pandas as pd
 import numpy as np
-
-np.random.seed(123)
 import argparse
 import NCF as ncf
 import pytorch_lightning as pl
@@ -12,44 +10,29 @@ import warnings
 import math
 import os
 from pathlib import Path
-
-warnings.simplefilter(action='ignore', category=FutureWarning)
-logging.set_verbosity_error()
-
-parser = argparse.ArgumentParser(description="""Preprocessor""")
-parser.add_argument('-f', '--filename', action='store', dest='filename', required=True,
-                    help="""string. csv recommender data""")
-
-parser.add_argument('--epochs', action='store', dest='epochs', default=5,
-                    help="""int number of epochs""")
-
-parser.add_argument('--batch_size', action='store', dest='batch_size', default=512,
-                    help="""int batch size""")
-
-parser.add_argument('--output_model_file', action='store', dest='output_model_file', default='model.pt',
-                    help="""string. filename for saving the model""")
-
+import time
 cnvrg_workdir = os.environ.get('CNVRG_WORKDIR', '/cnvrg')
+np.random.seed(int(time.time()))
 
-args = parser.parse_args()
-filename = args.filename
-epochs = int(args.epochs)
-batch_size = int(args.batch_size)
-output_model_file = args.output_model_file
+def add_timestamp_col(file_dir, filename):
+    ''' Adds timestamp column to the dataframe and returns it, also stores unique item ids in a json file '''
+    ratings = pd.read_csv(file_dir + "/" + filename)
+    ratings['timestamp'] = np.random.randint(0, 50000, size=len(ratings))
+    with open(file_dir + '/items_list.json', 'w') as outfile:
+        json.dump(list(set(ratings['item_id'])), outfile)
+    return ratings
 
-ratings = pd.read_csv(filename)
-ratings['timestamp'] = np.random.randint(0, 50000, size=len(ratings))
-with open(cnvrg_workdir + '/items_list.json', 'w') as outfile:
-    json.dump(list(set(ratings['item_id'])), outfile)
+def split_train_test(ratings):
+    ''' Returns the train and test data based on rank
+        Latest timestamp is categorised as the testing data 
+    '''
+    ratings['rank_latest'] = ratings.groupby(['user_id'])['timestamp'].rank(method='first', ascending=False)
+    train_ratings = ratings[ratings['rank_latest'] != 1]
+    test_ratings = ratings[ratings['rank_latest'] == 1]
+    return train_ratings, test_ratings
 
-ratings['rank_latest'] = ratings.groupby(['user_id'])['timestamp'].rank(method='first', ascending=False)
-
-train_ratings = ratings[ratings['rank_latest'] != 1]
-test_ratings = ratings[ratings['rank_latest'] == 1]
-print(train_ratings.dtypes)
-
-# If we have a weight column - duplicate each row x its weight times to make it have more/less impact on the model.
-if 'weight' in ratings.columns:
+def augment_data(train_ratings):
+    ''' Augements the data if 'weights' are given in the input data '''
     print(len(train_ratings))
     added_lines = pd.DataFrame()
     for row in range(len(train_ratings)):
@@ -60,58 +43,108 @@ if 'weight' in ratings.columns:
     added_lines.item_id = added_lines.item_id.astype(int)
     train_ratings = pd.concat([train_ratings, added_lines])
     print(len(train_ratings))
+    return train_ratings
 
-
-# drop columns that we no longer  need
-if 'rating' in ratings.columns:
-    train_ratings = train_ratings[['user_id', 'item_id', 'rating']]
-    test_ratings = test_ratings[['user_id', 'item_id', 'rating']]
-else:
-    train_ratings = train_ratings[['user_id', 'item_id']]
-    test_ratings = test_ratings[['user_id', 'item_id']]
-
-eval_metrics_whole = pd.DataFrame(columns=['user_id', 'rmse', 'precision', 'recall'])
-
-train_ratings.loc[:, 'rating'] = 1
-num_users = ratings['user_id'].max() + 1
-num_items = ratings['item_id'].max() + 1
-all_item_ids = ratings['item_id'].unique()
-
-print(type(num_items))
-print(type(num_users))
-print(type(all_item_ids))
-print(type(batch_size))
-
-model = ncf.NCF(num_users, num_items, train_ratings, all_item_ids, batch_size)
-
-trainer = pl.Trainer(max_epochs=int(epochs), gpus=1, reload_dataloaders_every_n_epochs=True, enable_checkpointing=False)
-recommend_whole = pd.DataFrame(columns=['user_id', 'item_id', 'score'])
-
-trainer.fit(model)
-
-# User-item pairs for testing
-test_user_item_set = set(zip(test_ratings['user_id'], test_ratings['item_id']))
-user1_movie_pred_whole = pd.DataFrame(columns=['user_id', 'item_id', 'rating', 'score', 'error'])
-
-# Dict of all items that are interacted with by each user
-user_interacted_items = ratings.groupby('user_id')['item_id'].apply(list).to_dict()
-
-recall = []
-for (u, i) in test_user_item_set:
-    interacted_items = user_interacted_items[u]
-    not_interacted_items = set(all_item_ids) - set(interacted_items)
-    selected_not_interacted = list(np.random.choice(list(not_interacted_items), 99))
-    test_items = selected_not_interacted + [i]
-
-    predicted_labels = np.squeeze(model(torch.tensor([u] * 100),
-                                        torch.tensor(test_items)).detach().numpy())
-
-    top10_items = [test_items[i] for i in np.argsort(predicted_labels)[::-1][0:10].tolist()]
-
-    if i in top10_items:
-        recall.append(1)
+def drop_colums(ratings, train_ratings, test_ratings):
+    ''' Drop un-necessary columns '''
+    if 'rating' in ratings.columns:
+        train_ratings = train_ratings[['user_id', 'item_id', 'rating']]
+        test_ratings = test_ratings[['user_id', 'item_id', 'rating']]
     else:
-        recall.append(0)
+        train_ratings = train_ratings[['user_id', 'item_id']]
+        test_ratings = test_ratings[['user_id', 'item_id']]
+    return train_ratings, test_ratings
 
-print("The hit ratio @ 10 is {:.2f}".format(np.average(recall)))
-torch.save(model, cnvrg_workdir + "/" + output_model_file)
+def get_data_attributes(ratings, train_ratings):
+    ''' Returns data attributes '''
+    train_ratings.loc[:, 'rating'] = 1
+    num_users = ratings['user_id'].max() + 1
+    num_items = ratings['item_id'].max() + 1
+    all_item_ids = ratings['item_id'].unique()
+    return train_ratings, num_users, num_items, all_item_ids
+
+def fit_model():
+    ''' Calls the training function  '''
+    model = ncf.NCF(num_users, num_items, train_ratings, all_item_ids, batch_size)
+    trainer = pl.Trainer(max_epochs=int(epochs), reload_dataloaders_every_n_epochs=True, enable_checkpointing=False, log_every_n_steps=1)
+    # recommend_whole = pd.DataFrame(columns=['user_id', 'item_id', 'score'])
+    trainer.fit(model)
+    return model, trainer
+
+def get_test_attributes(test_ratings, ratings):
+    '''
+        returns 
+            (user:item) set
+            (user: list(all items interacted by user)) dict 
+    '''
+    test_user_item_set = set(zip(test_ratings['user_id'], test_ratings['item_id']))
+    # user1_movie_pred_whole = pd.DataFrame(columns=['user_id', 'item_id', 'rating', 'score', 'error'])
+    user_interacted_items = ratings.groupby('user_id')['item_id'].apply(list).to_dict()
+    return test_user_item_set, user_interacted_items
+
+def get_recall(test_user_item_set, user_interacted_items):
+    ''' Calculates average recall '''
+    recall = []
+    for (u, i) in test_user_item_set:
+        interacted_items = user_interacted_items[u]
+        not_interacted_items = set(all_item_ids) - set(interacted_items)
+        selected_not_interacted = list(np.random.choice(list(not_interacted_items), 99))
+        test_items = selected_not_interacted + [i]
+
+        predicted_labels = np.squeeze(model(torch.tensor([u] * 100),
+                                            torch.tensor(test_items)).detach().numpy())
+
+        top10_items = [test_items[i] for i in np.argsort(predicted_labels)[::-1][0:10].tolist()]
+
+        if i in top10_items:
+            recall.append(1)
+        else:
+            recall.append(0)
+    return np.average(recall)
+
+def save_pt_model(file_dir, output_model_file):
+    torch.save(model, file_dir + "/" + output_model_file)
+
+if __name__ == "__main__":
+
+    warnings.simplefilter(action='ignore', category=FutureWarning)
+    logging.set_verbosity_error()
+
+    parser = argparse.ArgumentParser(description="""Preprocessor""")
+    parser.add_argument('-f', '--filename', action='store', dest='filename', required=True,
+                        help="""string. csv recommender data""")
+
+    parser.add_argument('--epochs', action='store', dest='epochs', default=5,
+                        help="""int number of epochs""")
+
+    parser.add_argument('--batch_size', action='store', dest='batch_size', default=512,
+                        help="""int batch size""")
+
+    parser.add_argument('--output_model_file', action='store', dest='output_model_file', default='model.pt',
+                        help="""string. filename for saving the model""")
+
+    parser.add_argument('--local_dir', action='store', dest='local_dir', default=cnvrg_workdir,
+                        help="""string. filename for saving the model""")
+
+    args = parser.parse_args()
+    filename = args.filename
+    epochs = int(args.epochs)
+    batch_size = int(args.batch_size)
+    output_model_file = args.output_model_file
+    file_dir = args.local_dir
+
+    ratings = add_timestamp_col(file_dir, filename)
+    train_ratings, test_ratings = split_train_test(ratings)
+    if 'weight' in ratings.columns:
+        train_ratings = augment_data(train_ratings)
+
+    train_ratings, test_ratings = drop_colums(ratings, train_ratings, test_ratings)
+    # eval_metrics_whole = pd.DataFrame(columns=['user_id', 'rmse', 'precision', 'recall']) - is this used ?
+ 
+    train_ratings, num_users, num_items, all_item_ids = get_data_attributes(ratings, train_ratings)
+    model, trainer = fit_model()
+    test_user_item_set, user_interacted_items = get_test_attributes(test_ratings, ratings)
+
+    average_recall = get_recall(test_user_item_set, user_interacted_items)
+    print("The hit ratio @ 10 is {:.2f}".format(average_recall))
+    save_pt_model(file_dir, output_model_file)

--- a/ncf_train/unittest_train.py
+++ b/ncf_train/unittest_train.py
@@ -1,0 +1,111 @@
+import pandas
+import unittest
+import os
+import sys
+import json
+import shutil
+from train import add_timestamp_col, split_train_test, augment_data, drop_colums, get_data_attributes, fit_model, get_test_attributes, get_recall
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+class test_train(unittest.TestCase):
+    @classmethod
+    def setUpClass(self):
+        # Create data for testing and define data parameters
+        df = pandas.DataFrame({ 
+            'user_id': [0,0,0,1,1,1,2,2,2,3,3,3,4,4,4],
+            'item_id': [0,1,2,3,2,5,1,3,5,2,4,6,1,5,3],
+            'weight':  [3,20,2,3,20,2,3,20,2,3,20,2,3,20,2]
+        })
+        self.test_data_len = len(set(df['user_id']))
+        self.train_data_len = len(df) - self.test_data_len
+        self.test_num_users = len(set(df['user_id']))
+        self.test_num_items = len(set(df['item_id']))
+        self.test_all_item_ids = list(set(df['item_id']))
+
+        # Make a Unit-testing directory
+        self.unittest_dir = "unit_test_data"
+        self.local_dir = os.path.dirname(os.path.abspath(__file__))
+        self.data_path = os.path.join(self.local_dir, self.unittest_dir)
+        os.mkdir(self.data_path)
+
+        # Store the csv data in the unittesting directory
+        df.to_csv(self.data_path + '/' + 'data.csv', index=False)
+
+        # Create test data frame
+        self.ratings = add_timestamp_col(self.data_path, 'data.csv')
+        # Split data into train and test
+        self.train_ratings, self.test_ratings = split_train_test(self.ratings)
+        # Augment train data
+        self.augment_train_ratings = augment_data(self.train_ratings)
+        # Drop the un-necessary columns 
+        self.drop_train_ratings, self.drop_test_ratings = drop_colums(self.ratings, self.train_ratings, self.test_ratings)
+        # Get data attributes and final data processing
+        self.final_train_ratings, self.num_users, self.num_items, self.all_item_ids = get_data_attributes(self.ratings, self.train_ratings)
+
+    @classmethod
+    def tearDownClass(self):
+        shutil.rmtree(self.data_path)
+
+    def test_return_df(self):
+        self.assertIsInstance(
+            self.ratings, pandas.core.frame.DataFrame
+        )
+
+    def test_add_timestamp_col(self):
+        self.assertTrue(
+            'timestamp' in self.ratings.columns
+        )
+    
+    def test_json_item_list(self):
+        with open(self.data_path + '/' + 'items_list.json', 'r') as json_file:
+            item_list = json.load(json_file)
+        self.assertListEqual(
+            item_list,
+            [0, 1, 2, 3, 4, 5, 6]
+        )
+
+    def test_train_test_len(self):
+        self.assertEqual(
+            len(self.train_ratings), self.train_data_len
+        )
+        self.assertEqual(
+            len(self.test_ratings), self.test_data_len
+        )
+    
+    def test_augment_data_len(self):
+        self.assertTrue(
+            len(self.augment_train_ratings) > len(self.train_ratings)
+        )
+
+    def test_drop_columns(self):
+        self.assertEqual(
+            len(self.drop_train_ratings.columns),
+            (2 or 3)
+        )
+        self.assertEqual(
+            len(self.drop_test_ratings.columns),
+            (2 or 3)
+        )
+        if len(self.drop_train_ratings.columns) == 2 and len(self.drop_test_ratings.columns) == 2:
+            self.assertListEqual(
+                list(self.drop_train_ratings.columns),
+                ['user_id', 'item_id']
+            )
+            self.assertListEqual(
+                list(self.drop_train_ratings.columns),
+                ['user_id', 'item_id']
+            )
+        else:
+            self.assertListEqual(
+                list(self.drop_train_ratings.columns),
+                ['user_id', 'item_id', 'rating']
+            )
+            self.assertListEqual(
+                list(self.drop_train_ratings.columns),
+                ['user_id', 'item_id', 'rating']
+            )
+
+    def test_data_attributes(self):
+        self.assertEqual(self.num_users, self.test_num_users)
+        self.assertEqual(self.num_items, self.test_num_items)
+        self.assertListEqual(sorted(list(self.all_item_ids)), self.test_all_item_ids)

--- a/ncf_train/unittest_train.py
+++ b/ncf_train/unittest_train.py
@@ -22,7 +22,8 @@ class test_train(unittest.TestCase):
         self.test_num_items = len(set(df['item_id']))
         self.test_all_item_ids = list(set(df['item_id']))
         self.epochs = 100
-        self.batch_size = 512 
+        self.batch_size = 512
+        self.num_workers = 0
 
         # Make a Unit-testing directory
         self.unittest_dir = "unit_test_data"
@@ -44,7 +45,7 @@ class test_train(unittest.TestCase):
         # Get data attributes and final data processing
         self.final_train_ratings, self.num_users, self.num_items, self.all_item_ids = get_data_attributes(self.ratings, self.train_ratings)
         # Train the model on the above defined data
-        self.model, self.trainer = fit_model(self.num_users, self.num_items, self.final_train_ratings, self.all_item_ids, self.batch_size, self.epochs)
+        self.model, self.trainer = fit_model(self.num_users, self.num_items, self.final_train_ratings, self.all_item_ids, self.batch_size, self.epochs, self.num_workers)
         # Get test data attributes
         self.test_user_item_set, self.user_interacted_items = get_test_attributes(self.test_ratings, self.ratings)
         # Get the average recall for the model
@@ -58,16 +59,19 @@ class test_train(unittest.TestCase):
         shutil.rmtree(self.data_path)
 
     def test_return_df(self):
+        ''' Checks if pandas dataframe is retuned '''
         self.assertIsInstance(
             self.ratings, pandas.core.frame.DataFrame
         )
 
     def test_add_timestamp_col(self):
+        ''' Checks if the timestamp column is added to the data '''
         self.assertTrue(
             'timestamp' in self.ratings.columns
         )
     
     def test_json_item_list(self):
+        ''' Checks the content of 'items_list.json' '''
         test_item_list = [i for i in range(self.num_users)]
         with open(self.data_path + '/' + 'items_list.json', 'r') as json_file:
             item_list = json.load(json_file)
@@ -77,19 +81,25 @@ class test_train(unittest.TestCase):
         )
 
     def test_train_test_len(self):
+        ''' Checks the length of train, test dataset '''
         self.assertEqual(
             len(self.train_ratings), self.train_data_len
         )
         self.assertEqual(
             len(self.test_ratings), self.test_data_len
         )
-    
+
     def test_augment_data_len(self):
+        ''' Checks if data has been augmented '''
         self.assertTrue(
             len(self.augment_train_ratings) > len(self.train_ratings)
         )
 
     def test_drop_columns(self):
+        '''
+            Checks if un-necessary columns have been droped in train, test dataset
+            Checks if the correct columns are present in the train, test dataset
+        '''
         self.assertEqual(
             len(self.drop_train_ratings.columns),
             (2 or 3)
@@ -118,11 +128,13 @@ class test_train(unittest.TestCase):
             )
 
     def test_data_attributes(self):
+        ''' Checks if data attributes are extracted correctly based on the data defined in setUpClass  '''
         self.assertEqual(self.num_users, self.test_num_users)
         self.assertEqual(self.num_items, self.test_num_items)
         self.assertListEqual(sorted(list(self.all_item_ids)), self.test_all_item_ids)
 
     def test_model_trainer(self):
+        ''' Checks if model and trainer objects are returned '''
         self.assertTrue(
             self.model
         )
@@ -131,11 +143,13 @@ class test_train(unittest.TestCase):
         )
 
     def test_average_recall_value(self):
+        ''' Checks the average recall value returned and if it falls within the below specified interval based on data defined in setUpClass '''
         self.assertTrue(
             0.75 <= self.avg_recall <= 1.0
         )
 
     def test_model_file_exists(self):
+        ''' Checks if the model.pt filed is saved '''
         self.assertTrue(
             os.path.isfile(self.data_path + '/' + self.output_model_file)
         )

--- a/ncf_train/unittest_train.py
+++ b/ncf_train/unittest_train.py
@@ -48,7 +48,7 @@ class test_train(unittest.TestCase):
         # Train the model on the above defined data
         self.model, self.trainer = fit_model(self.num_users, self.num_items, self.final_train_ratings, self.all_item_ids, self.batch_size, self.epochs, self.num_workers)
         # Get test data attributes
-        self.test_user_item_set, self.user_interacted_items = get_test_attributes(self.test_ratings, self.ratings)
+        self.test_user_item_set, self.user_interacted_items = get_test_attributes(self.drop_test_ratings, self.ratings)
         # Get the average recall for the model
         self.avg_recall = get_recall(self.test_user_item_set, self.user_interacted_items, self.all_item_ids, self.model)
         # Save the trained model

--- a/ncf_train/unittest_train.py
+++ b/ncf_train/unittest_train.py
@@ -10,6 +10,7 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 class test_train(unittest.TestCase):
     @classmethod
     def setUpClass(self):
+        ''' Function used to set up test dataframe and unittesting parameters '''
         # Create data for testing and define data parameters
         df = pandas.DataFrame({ 
             'user_id': [0,0,0,1,1,1,2,2,2,3,3,3,4,4,4],
@@ -56,6 +57,7 @@ class test_train(unittest.TestCase):
 
     @classmethod
     def tearDownClass(self):
+        ''' Clean up function '''
         shutil.rmtree(self.data_path)
 
     def test_return_df(self):
@@ -132,15 +134,6 @@ class test_train(unittest.TestCase):
         self.assertEqual(self.num_users, self.test_num_users)
         self.assertEqual(self.num_items, self.test_num_items)
         self.assertListEqual(sorted(list(self.all_item_ids)), self.test_all_item_ids)
-
-    def test_model_trainer(self):
-        ''' Checks if model and trainer objects are returned '''
-        self.assertTrue(
-            self.model
-        )
-        self.assertTrue(
-            self.trainer
-        )
 
     def test_average_recall_value(self):
         ''' Checks the average recall value returned and if it falls within the below specified interval based on data defined in setUpClass '''

--- a/ncf_train/unittest_train_dataset.py
+++ b/ncf_train/unittest_train_dataset.py
@@ -8,19 +8,23 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 class test_train(unittest.TestCase):
     @classmethod
     def setUpClass(self):
+        ''' Function used to set up test dataframe and unittesting parameters '''
+        # Create a dataframe for testing 
         self.ratings = pandas.DataFrame({ 
             'user_id': [0,0,0,1,1,1,2,2,2,3,3,3,4,4,4],
             'item_id': [0,0,0,1,1,1,2,2,2,3,3,3,4,4,4],
         })
+        # Retrieve all unique items in a list
         self.all_item_ids = list(set(self.ratings['item_id']))
 
-        # Call the get_dataset function on the above data
+        # Call the get_dataset function on the above defined data
         self.td = TrainDataset(self.ratings, self.all_item_ids)
         self.data_item_label_tuple = set()
         for user, item, label in zip(list(self.td.users), list(self.td.items), list(self.td.labels)):
             self.data_item_label_tuple.add((user, item, label))
 
     def data_labels_helper(self):
+        ''' Checks if get_dataset function assigns correct labels to each user, item pair - based on the data defined in setUpClass above '''
         for user, item, label in self.data_item_label_tuple:
             if (user == item):
                 if label == 0:
@@ -31,7 +35,7 @@ class test_train(unittest.TestCase):
         return True
 
     def test_data_labels(self):
-        ''' Checks if the get_data function produces the correct labels '''
+        ''' Checks if the get_dataset function produces the correct labels '''
         self.assertTrue(
             self.data_labels_helper()
         )

--- a/ncf_train/unittest_train_dataset.py
+++ b/ncf_train/unittest_train_dataset.py
@@ -31,6 +31,7 @@ class test_train(unittest.TestCase):
         return True
 
     def test_data_labels(self):
+        ''' Checks if the get_data function produces the correct labels '''
         self.assertTrue(
             self.data_labels_helper()
         )

--- a/ncf_train/unittest_train_dataset.py
+++ b/ncf_train/unittest_train_dataset.py
@@ -1,0 +1,36 @@
+import pandas
+import unittest
+import os
+import sys
+from TrainDataset import TrainDataset
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+class test_train(unittest.TestCase):
+    @classmethod
+    def setUpClass(self):
+        self.ratings = pandas.DataFrame({ 
+            'user_id': [0,0,0,1,1,1,2,2,2,3,3,3,4,4,4],
+            'item_id': [0,0,0,1,1,1,2,2,2,3,3,3,4,4,4],
+        })
+        self.all_item_ids = list(set(self.ratings['item_id']))
+
+        # Call the get_dataset function on the above data
+        self.td = TrainDataset(self.ratings, self.all_item_ids)
+        self.data_item_label_tuple = set()
+        for user, item, label in zip(list(self.td.users), list(self.td.items), list(self.td.labels)):
+            self.data_item_label_tuple.add((user, item, label))
+
+    def data_labels_helper(self):
+        for user, item, label in self.data_item_label_tuple:
+            if (user == item):
+                if label == 0:
+                    return False
+            else:
+                if label == 1:
+                    return False
+        return True
+
+    def test_data_labels(self):
+        self.assertTrue(
+            self.data_labels_helper()
+        )


### PR DESCRIPTION
1) Refactored the 'train.py' script to make it unit-testable, for example:- added functions, extra arguments to it (local dir and configurable support for num_workers)
2) Added unit-testing scripts to it, the coverage gained is as below:
<img width="1728" alt="Screen Shot 2022-11-16 at 4 17 49 PM" src="https://user-images.githubusercontent.com/69989070/202313434-9ab608d3-2326-49f8-b904-1a3ea6620d73.png">

3) @HolzerNaama I think the dataframes defined on line 91, 102, 166 (in the refactored file, commented out) are not used anywhere, could you please check if we still require them - I will delete those if not required
4) @sabinastanescu @Ramji-Satya I don't know how the process of pushing the renewed code to market place works? Do we first merge this PR into master and then deploy to production (pushing to the marketplace)? Because of this I have been holding back to create PR's for my connector unit-tests and refactoring efforts as well